### PR TITLE
Add code for exercises given in ramp-up session 1

### DIFF
--- a/exercises/arane/Dockerfile
+++ b/exercises/arane/Dockerfile
@@ -1,0 +1,24 @@
+# Selecting golang as the base image
+FROM golang AS builder
+
+# Creating a Directory to store hello-openshift.go and binary
+RUN mkdir openshift-ramp-up-session-1
+
+# Copying hello-openshift.go to above directory
+COPY hello-openshift.go openshift-ramp-up-session-1/
+
+# Building binary from hello-openshift.go
+RUN go build -o openshift-ramp-up-session-1/hello-openshift openshift-ramp-up-session-1/hello-openshift.go
+
+# Doing multi-stage build so as to keep only hello-openshift binary and avoid other artifacts from golang image
+# Selecting ubi8 as base image 
+FROM ubi8
+
+# Creating a Directory to store hello-openshift.go binary
+RUN mkdir openshift-ramp-up-session-1
+
+# Copying binary from previous build stage to current build stage
+COPY --from=builder go/openshift-ramp-up-session-1/hello-openshift openshift-ramp-up-session-1/
+
+# Setting binary of hello-openshift.go as entrypoint
+ENTRYPOINT ["./openshift-ramp-up-session-1/hello-openshift"]

--- a/exercises/arane/hello-openshift.go
+++ b/exercises/arane/hello-openshift.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+// Main function to print 
+func main() {
+    
+    // Printing "Hello OpenShift"
+    fmt.Println("Hello OpenShift")
+}


### PR DESCRIPTION
This PR includes code for the exercises given in Boston ramp up session 1. Two files are part of this commit:

1) hello-openshift.go - Go code that prints "Hello Openshift" to stdout

2) Dockerfile - Compiles the above go code with golang as the base image. The binary obtained from the first build stage is copied into the second build stage with ubi8 as the base image so as to avoid the unnecessary artifacts being included from golang image. It also sets the binary as the entrypoint of the container  

